### PR TITLE
Fix serial tty not activated after boot

### DIFF
--- a/conf/machine/include/pcengines-apux.inc
+++ b/conf/machine/include/pcengines-apux.inc
@@ -7,7 +7,7 @@ MULTILIBS ?= ""
 require conf/multilib.conf
 
 # Add serial consoles to kernel commandline
-SERIAL_CONSOLES = "115200;ttyUSB0"
+SERIAL_CONSOLES = "115200;ttyS0"
 KERNEL_SERIAL_CONSOLE ??= "console=ttyS0,115200n8"
 APPEND += "${KERNEL_SERIAL_CONSOLE}"
 


### PR DESCRIPTION
Hardware serial tty of APU board is recognized as ttyS0.