### PR TITLE
Fix failing build due to unused multilib support

### DIFF
--- a/conf/machine/include/pcengines-apux.inc
+++ b/conf/machine/include/pcengines-apux.inc
@@ -3,9 +3,6 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 # provides gcc tune for Family 16h
 require conf/machine/include/tune-dbft3b.inc
 
-MULTILIBS ?= ""
-require conf/multilib.conf
-
 # Add serial consoles to kernel commandline
 SERIAL_CONSOLES = "115200;ttyUSB0"
 KERNEL_SERIAL_CONSOLE ??= "console=ttyS0,115200n8"


### PR DESCRIPTION
Remove multilib dependency since it not used by default, how-ever
specifing it within the machine configuration causes issues when
building packages which do not support multilib.

If somebody really needs this feature, I suggest adding it to local.conf
as suggested by the manual [1].

[1]  https://www.yoctoproject.org/docs/3.1.2/mega-manual/mega-manual.html#combining-multiple-versions-library-files-into-one-image